### PR TITLE
Fixes for when multistage isn't being used

### DIFF
--- a/lib/capistrano/deploy_lock.rb
+++ b/lib/capistrano/deploy_lock.rb
@@ -18,7 +18,11 @@ module Capistrano
 
   module DeployLock
     def self.message(application, stage, deploy_lock)
-      message = "#{application} (#{stage}) was locked"
+      if stage
+        message = "#{application} (#{stage}) was locked"
+      else
+        message = "#{application} was locked"
+      end
       if defined?(Capistrano::DateHelper)
         locked_ago = Capistrano::DateHelper.distance_of_time_in_words_to_now deploy_lock[:created_at].localtime
         message << " #{locked_ago} ago"
@@ -35,7 +39,7 @@ module Capistrano
           message << "\nExpires at #{deploy_lock[:expire_at].localtime.strftime("%H:%M:%S")}"
         end
       else
-        message << "\nLock must be manually removed with: cap #{stage} deploy:unlock"
+        message << "\nLock must be manually removed with: cap #{stage ? stage + ' ' : ''}deploy:unlock"
       end
     end
   end

--- a/lib/capistrano/recipes/deploy_lock.rb
+++ b/lib/capistrano/recipes/deploy_lock.rb
@@ -124,7 +124,7 @@ Capistrano::Configuration.instance(:must_exist).load do
       stg = nil
       begin
         stg = stage
-      rescue NoMethodError
+      rescue NameError
         # this means we don't have multistage. ok.
       end
 

--- a/lib/capistrano/recipes/deploy_lock.rb
+++ b/lib/capistrano/recipes/deploy_lock.rb
@@ -121,15 +121,8 @@ Capistrano::Configuration.instance(:must_exist).load do
         next
       end
 
-      stg = nil
-      begin
-        stg = stage
-      rescue NameError
-        # this means we don't have multistage. ok.
-      end
-
       # Unexpired lock is present, so display the lock message
-      logger.important Capistrano::DeployLock.message(application, stg, deploy_lock)
+      logger.important Capistrano::DeployLock.message(application, (respond_to?(:stage) ? stage : nil), deploy_lock)
 
       # Don't raise exception if current user owns the lock.
       # Just sleep so they have a chance to Ctrl-C

--- a/lib/capistrano/recipes/deploy_lock.rb
+++ b/lib/capistrano/recipes/deploy_lock.rb
@@ -121,8 +121,15 @@ Capistrano::Configuration.instance(:must_exist).load do
         next
       end
 
+      stg = nil
+      begin
+        stg = stage
+      rescue NoMethodError
+        # this means we don't have multistage. ok.
+      end
+
       # Unexpired lock is present, so display the lock message
-      logger.important Capistrano::DeployLock.message(application, stage, deploy_lock)
+      logger.important Capistrano::DeployLock.message(application, stg, deploy_lock)
 
       # Don't raise exception if current user owns the lock.
       # Just sleep so they have a chance to Ctrl-C


### PR DESCRIPTION
The current code assumes the usage of capistrano multistage. In particular, the #stage method is used, which crashes in its absence. I've changed this to ignore stage-related stuff when calling that method results in a NameError.
