### PR TITLE
Fixes errors on multiple servers and stage

### DIFF
--- a/lib/capistrano/recipes/deploy_lock.rb
+++ b/lib/capistrano/recipes/deploy_lock.rb
@@ -133,7 +133,7 @@ Capistrano::Configuration.instance(:must_exist).load do
       next unless self[:deploy_lock]
 
       if deploy_lock[:expire_at] && deploy_lock[:expire_at] < Time.now
-        logger.info Capistrano::DeployLock.expired_message(application, stage, deploy_lock)
+        logger.info Capistrano::DeployLock.expired_message(application, (respond_to?(:stage) ? stage : nil), deploy_lock)
         remove_deploy_lock
         next
       end


### PR DESCRIPTION
When I am using two servers it checks for lock on each server twice 
parallel(n) -> find_servers(n)
will result in n**2 loop

Instead changed it to check if the current session's IP is among the servers for the current task 

```
** Deploy lock found on: <IP>
/home/hasan/.rvm/gems/ruby-1.9.3-p448-railsexpress@mentor/gems/capistrano-2.15.4/lib/capistrano/transfer.rb:157:in `[]=': undefined method `[]=' for nil:NilClass (NoMethodError)
    from /home/hasan/.rvm/gems/ruby-1.9.3-p448-railsexpress@mentor/gems/capistrano-2.15.4/lib/capistrano/transfer.rb:212:in `handle_error'
  ...
    from /home/hasan/.rvm/gems/ruby-1.9.3-p448-railsexpress@mentor/gems/capistrano-2.15.4/lib/capistrano/configuration/actions/file_transfer.rb:13:in `put'
    from /home/hasan/.rvm/gems/ruby-1.9.3-p448-railsexpress@mentor/gems/capistrano-2.15.4/lib/capistrano/configuration/namespaces.rb:191:in `method_missing'
    from /home/hasan/.rvm/gems/ruby-1.9.3-p448-railsexpress@mentor/gems/capistrano_deploy_lock-1.3.3/lib/capistrano/recipes/deploy_lock.rb:40:in `write_deploy_lock'
    from /home/hasan/.rvm/gems/ruby-1.9.3-p448-railsexpress@mentor/gems/capistrano_deploy_lock-1.3.3/lib/capistrano/recipes/deploy_lock.rb:177:in `block (3 levels) in <top (required)>'
```

Missed adding respond_to?(:stage) when lock is expired

```
** Deploy lock found on: <IP>
/home/chronus/.rvm/gems/ruby-1.9.3-p448-railsexpress@mentor/gems/capistrano-2.15.4/lib/capistrano/configuration/namespaces.rb:193:in `method_missing': undefined local variable or method `stage' for #<Capistrano::Configuration::Namespaces::Namespace:0x000000027f53a8> (NameError)
from /home/chronus/.rvm/gems/ruby-1.9.3-p448-railsexpress@mentor/gems/capistrano_deploy_lock-1.3.3/lib/capistrano/recipes/deploy_lock.rb:136:in `block (3 levels) in <top (required)>'
from /home/chronus/.rvm/gems/ruby-1.9.3-p448-railsexpress@mentor/gems/capistrano-2.15.4/lib/capistrano/configuration/execution.rb:138:in `instance_eval'
```
