### PR TITLE
Fix return statement

### DIFF
--- a/lib/capistrano/deploy_lock.rb
+++ b/lib/capistrano/deploy_lock.rb
@@ -56,7 +56,7 @@ module Capistrano
           expires_in = Capistrano::DateHelper.distance_of_time_in_words_to_now deploy_lock[:expire_at].localtime
           message << "\nLock expired #{expires_in} ago, unlocking..."
         else
-          message << "\nLock expired at #{deploy_lock[:expire_at].localtime.strftime("%H:%M:%S")}"
+          message << "\nLock expired at #{deploy_lock[:expire_at].localtime.strftime("%Y-%m-%d %H:%M:%S %z")}"
         end
       else
         message << "\nLock must be manually removed with: cap #{stage ? stage + ' ' : ''}deploy:unlock"

--- a/lib/capistrano/recipes/deploy_lock.rb
+++ b/lib/capistrano/recipes/deploy_lock.rb
@@ -23,16 +23,18 @@ Capistrano::Configuration.instance(:must_exist).load do
         parallel do |session|
           find_servers_for_task(current_task).each do |current_server|
             session.else "[ -e #{deploy_lockfile} ] && cat #{deploy_lockfile} || true" do |ch, stream, output|
-              if output && output != ""
+              # this sets the lock value on the first server we found
+              if self[:deploy_lock].nil? && output && output != ""
                 logger.info "Deploy lock found on: #{current_server.host}"
                 set :deploy_lock, YAML.load(output)
-                return
               end
             end
           end
         end
 
-        set :deploy_lock, false
+        if self[:deploy_lock].nil?
+          set :deploy_lock, false
+        end
       end
     end
 


### PR DESCRIPTION
Reproducing this error:
1- For the purpose of this test, set the default time expiry to 1 (`set :default_lock_expiry, 1`)
2- Run `cap deploy:create_lock`
3- Run `cap deploy:check_lock`

In my case it produced something like:

```
Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano_deploy_lock-1.3.3/lib/capistrano/recipes/deploy_lock.rb:29:in `block (3 levels) in fetch_deploy_lock': unexpected return (LocalJumpError)
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/command.rb:241:in `[]'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/command.rb:241:in `block (4 levels) in open_channels'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/net-ssh-2.9.1/lib/net/ssh/connection/channel.rb:569:in `call'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/net-ssh-2.9.1/lib/net/ssh/connection/channel.rb:569:in `do_data'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/net-ssh-2.9.1/lib/net/ssh/connection/session.rb:566:in `channel_data'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/net-ssh-2.9.1/lib/net/ssh/connection/session.rb:465:in `dispatch_incoming_packets'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/net-ssh-2.9.1/lib/net/ssh/connection/session.rb:221:in `preprocess'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/processable.rb:17:in `block in process_iteration'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/processable.rb:45:in `block in ensure_each_session'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/processable.rb:43:in `each'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/processable.rb:43:in `ensure_each_session'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/processable.rb:17:in `process_iteration'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/command.rb:171:in `block (2 levels) in process!'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/command.rb:170:in `loop'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/command.rb:170:in `block in process!'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/2.1.0/benchmark.rb:294:in `realtime'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/command.rb:169:in `process!'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/command.rb:140:in `process'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/actions/invocation.rb:198:in `block in run_tree'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/connections.rb:205:in `block in execute_on_servers'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/connections.rb:193:in `each'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/connections.rb:193:in `each_slice'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/connections.rb:193:in `execute_on_servers'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/actions/invocation.rb:196:in `run_tree'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/actions/invocation.rb:155:in `run'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/namespaces.rb:191:in `method_missing'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano_deploy_lock-1.3.3/lib/capistrano/recipes/deploy_lock.rb:44:in `remove_deploy_lock'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano_deploy_lock-1.3.3/lib/capistrano/recipes/deploy_lock.rb:137:in `block (3 levels) in <top (required)>'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:138:in `instance_eval'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:138:in `invoke_task_directly'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/callbacks.rb:25:in `invoke_task_directly_with_callbacks'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:89:in `execute_task'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:101:in `find_and_execute_task'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/cli/execute.rb:46:in `block in execute_requested_actions'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/cli/execute.rb:45:in `each'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/cli/execute.rb:45:in `execute_requested_actions'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/cli/help.rb:19:in `execute_requested_actions_with_help'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/cli/execute.rb:34:in `execute!'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/lib/capistrano/cli/execute.rb:14:in `execute'
        from /Users/kouno/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/capistrano-2.15.5/bin/cap:4:in `<top (required)>'
        from ./bin/cap:16:in `load'
        from ./bin/cap:16:in `<main>'
```

I first thought that it was related to my ruby version, but testing it on 1.9.3 didn't fix it either (using 2.1.2 at the moment). A problem with capistrano version? I doubt it... Anyway here's a fix.

Also, I added the date when inspecting a lock as `%H:%M:%S` was a bit lacking. For instance, was my lock created yesterday morning? or this morning?
